### PR TITLE
Fix FeatureServiceTest test fails in eval/debugger-demo branch #12

### DIFF
--- a/src/test/java/com/sivalabs/ft/features/domain/feature/FeatureServiceTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/feature/FeatureServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @Import(DatabaseConfiguration.class)
@@ -24,10 +25,10 @@ import org.springframework.test.context.TestPropertySource;
 class FeatureServiceTest {
 
     @Autowired
-    FeatureService featureService;
+    private FeatureService featureService;
 
-    @Autowired
-    EventPublisher eventPublisher;
+    @MockitoBean
+    private EventPublisher eventPublisher;
 
     @BeforeEach
     void resetMocks() {


### PR DESCRIPTION
Test `shouldGetFeaturesByReleaseCode` in test class `FeatureControllerTests` fails with error
```
jakarta.servlet.ServletException: Request processing failed: org.hibernate.LazyInitializationException: Could not initialize proxy [com.sivalabs.ft.features.domain.product.Product#1] - no session
```
Fix the test.

FAIL_TO_PASS: FeatureServiceTest