### PR TITLE
Add request ID information from the HTTP request header to SLF4J MDC log #45

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/logging/LogRequestFilter.java
+++ b/src/main/java/com/sivalabs/ft/features/logging/LogRequestFilter.java
@@ -1,0 +1,52 @@
+package com.sivalabs.ft.features.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Filter that adds contextual information to MDC for logging
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class LogRequestFilter extends OncePerRequestFilter {
+
+    private static final String REQUEST_ID_HEADER = "X-Request-ID";
+    private static final String REQUEST_ID_KEY = "requestId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            // Get or generate request ID
+            String requestId = request.getHeader(REQUEST_ID_HEADER);
+            if (requestId == null || requestId.isBlank()) {
+                requestId = UUID.randomUUID().toString();
+            }
+
+            // Add the request ID to the response header
+            response.addHeader(REQUEST_ID_HEADER, requestId);
+
+            // Add request ID to MDC
+            MDC.put(REQUEST_ID_KEY, requestId);
+
+            // Continue with the filter chain
+            filterChain.doFilter(request, response);
+
+        } finally {
+            // Clear MDC values after request completes
+            MDC.remove(REQUEST_ID_KEY);
+            // Clear entire MDC to be safe
+            MDC.clear();
+        }
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/logging/LogRequestFilterIntegrationTest.java
+++ b/src/test/java/com/sivalabs/ft/features/logging/LogRequestFilterIntegrationTest.java
@@ -1,0 +1,116 @@
+package com.sivalabs.ft.features.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.TestcontainersConfiguration;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Import({
+    TestcontainersConfiguration.class,
+    LogRequestFilterIntegrationTest.TestConfig.class,
+    LogRequestFilterIntegrationTest.TestController.class
+})
+class LogRequestFilterIntegrationTest extends AbstractIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MDCCapturingFilter mdcCapturingFilter;
+
+    @AfterEach
+    void tearDown() {
+        // Clear security context after each test
+        SecurityContextHolder.clearContext();
+        MDC.clear();
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldAddRequestIdToResponseHeadersWhenProvided() throws Exception {
+        // Given
+        String requestId = "test-request-id-123";
+
+        // When/Then
+        mockMvc.perform(get("/test-endpoint").header("X-Request-ID", requestId))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Request-ID", requestId));
+
+        // Verify MDC was set correctly during request processing
+        assertThat(mdcCapturingFilter.getCapturedRequestId()).isEqualTo(requestId);
+    }
+
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldGenerateRequestIdWhenNotProvided() throws Exception {
+        // When
+        MvcResult result = mockMvc.perform(get("/test-endpoint"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // Then
+        String generatedRequestId = result.getResponse().getHeader("X-Request-ID");
+        assertThat(generatedRequestId).isNotNull().isNotEmpty();
+        assertThat(mdcCapturingFilter.getCapturedRequestId()).isEqualTo(generatedRequestId);
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public MDCCapturingFilter mdcCapturingFilter() {
+            return new MDCCapturingFilter();
+        }
+    }
+
+    @RestController
+    static class TestController {
+        @GetMapping("/test-endpoint")
+        public String test() {
+            return "test";
+        }
+    }
+
+    /**
+     * Special filter that captures MDC values during request processing
+     * This runs after the RequestContextFilter but before the request completes
+     */
+    static class MDCCapturingFilter extends OncePerRequestFilter {
+        private final AtomicReference<String> requestId = new AtomicReference<>();
+
+        @Override
+        protected void doFilterInternal(
+                HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+                throws jakarta.servlet.ServletException, java.io.IOException {
+            // Capture the MDC values set by the RequestContextFilter
+            requestId.set(MDC.get("requestId"));
+
+            filterChain.doFilter(request, response);
+        }
+
+        public String getCapturedRequestId() {
+            return requestId.get();
+        }
+    }
+}


### PR DESCRIPTION
Add request ID information from the HTTP request header to SLF4J MDC log #45

Add request ID information from the HTTP request header X-Request-ID to the SLF4J MDC log as requestId to enable request tracing across service calls.

FAIL_TO_PASS: LogRequestFilterIntegrationTest