### PR TITLE
Implement Synchronous Application Event Publishing and Listening for Feature Creation #47

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/events/EventPublisher.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/EventPublisher.java
@@ -3,6 +3,7 @@ package com.sivalabs.ft.features.domain.events;
 import com.sivalabs.ft.features.ApplicationProperties;
 import com.sivalabs.ft.features.domain.entities.Feature;
 import java.time.Instant;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -10,13 +11,26 @@ import org.springframework.stereotype.Component;
 public class EventPublisher {
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final ApplicationProperties properties;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
-    public EventPublisher(KafkaTemplate<String, Object> kafkaTemplate, ApplicationProperties properties) {
+    public EventPublisher(
+            KafkaTemplate<String, Object> kafkaTemplate, 
+            ApplicationProperties properties,
+            ApplicationEventPublisher applicationEventPublisher) {
         this.kafkaTemplate = kafkaTemplate;
         this.properties = properties;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
+    /**
+     * Publishes a feature created event both to Kafka and as a Spring ApplicationEvent.
+     * The Kafka event is used for inter-service communication, while the ApplicationEvent
+     * is used for synchronous handling within this application.
+     *
+     * @param feature the Feature entity that was created
+     */
     public void publishFeatureCreatedEvent(Feature feature) {
+        // Publish to Kafka for inter-service communication
         FeatureCreatedEvent event = new FeatureCreatedEvent(
                 feature.getId(),
                 feature.getCode(),
@@ -28,6 +42,9 @@ public class EventPublisher {
                 feature.getCreatedBy(),
                 feature.getCreatedAt());
         kafkaTemplate.send(properties.events().newFeatures(), event);
+        
+        // Publish Spring ApplicationEvent for synchronous handling within the application
+        applicationEventPublisher.publishEvent(new FeatureCreatedApplicationEvent(this, feature));
     }
 
     public void publishFeatureUpdatedEvent(Feature feature) {

--- a/src/main/java/com/sivalabs/ft/features/domain/events/FeatureCreatedApplicationEvent.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/FeatureCreatedApplicationEvent.java
@@ -1,0 +1,34 @@
+package com.sivalabs.ft.features.domain.events;
+
+import com.sivalabs.ft.features.domain.entities.Feature;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Spring ApplicationEvent that is published when a new Feature is created.
+ * This event is published synchronously and can be handled by components
+ * within the application using the @EventListener annotation.
+ */
+public class FeatureCreatedApplicationEvent extends ApplicationEvent {
+    private final Feature feature;
+
+    /**
+     * Create a new FeatureCreatedApplicationEvent.
+     *
+     * @param source the object on which the event initially occurred or with
+     *               which the event is associated (never {@code null})
+     * @param feature the Feature entity that was created
+     */
+    public FeatureCreatedApplicationEvent(Object source, Feature feature) {
+        super(source);
+        this.feature = feature;
+    }
+
+    /**
+     * Get the Feature entity that was created.
+     *
+     * @return the Feature entity
+     */
+    public Feature getFeature() {
+        return feature;
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/FeatureEventListener.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/FeatureEventListener.java
@@ -1,0 +1,36 @@
+package com.sivalabs.ft.features.domain.events;
+
+import com.sivalabs.ft.features.domain.entities.Feature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Component that listens for Feature-related application events.
+ * This listener handles events synchronously within the application.
+ */
+@Component
+public class FeatureEventListener {
+    private static final Logger logger = LoggerFactory.getLogger(FeatureEventListener.class);
+
+    /**
+     * Handles FeatureCreatedApplicationEvent.
+     * This method is called synchronously when a new Feature is created.
+     * It logs feature details and can perform additional business logic as needed.
+     *
+     * @param event the FeatureCreatedApplicationEvent containing the created Feature
+     */
+    @EventListener
+    public void handleFeatureCreatedEvent(FeatureCreatedApplicationEvent event) {
+        Feature feature = event.getFeature();
+        logger.info("Feature created event received - ID: {}, Name: {}", 
+                feature.getId(), feature.getTitle());
+        
+        // Additional business logic can be added here
+        // For example:
+        // - Send notifications
+        // - Update statistics
+        // - Trigger other processes
+    }
+}

--- a/src/test/java/com/sivalabs/ft/features/domain/events/FeatureEventTests.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/events/FeatureEventTests.java
@@ -1,0 +1,143 @@
+package com.sivalabs.ft.features.domain.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import com.sivalabs.ft.features.domain.FeatureService;
+import com.sivalabs.ft.features.domain.Commands.CreateFeatureCommand;
+import com.sivalabs.ft.features.domain.entities.Feature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+/**
+ * Tests for the Feature event flow.
+ * These tests verify that events are published and handled correctly when features are created.
+ */
+class FeatureEventTests extends AbstractIT {
+
+    @Autowired
+    private FeatureService featureService;
+    
+    @Autowired
+    private TestEventListener testEventListener;
+    
+    @BeforeEach
+    void setUp() {
+        testEventListener.reset();
+    }
+    
+    /**
+     * Test configuration that provides a test event listener to capture events.
+     */
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        @Primary
+        public TestEventListener testEventListener() {
+            return new TestEventListener();
+        }
+    }
+    
+    /**
+     * Test event listener that captures FeatureCreatedApplicationEvents for verification.
+     */
+    static class TestEventListener {
+        private final FeatureEventListener delegate = mock(FeatureEventListener.class);
+        
+        void reset() {
+            clearInvocations(delegate);
+        }
+        
+        @EventListener
+        public void handleFeatureCreatedEvent(FeatureCreatedApplicationEvent event) {
+            delegate.handleFeatureCreatedEvent(event);
+        }
+        
+        public void verifyEventReceived(int times) {
+            verify(delegate, times(times)).handleFeatureCreatedEvent(any(FeatureCreatedApplicationEvent.class));
+        }
+        
+        public Feature getCapturedFeature() {
+            ArgumentCaptor<FeatureCreatedApplicationEvent> captor = ArgumentCaptor.forClass(FeatureCreatedApplicationEvent.class);
+            verify(delegate).handleFeatureCreatedEvent(captor.capture());
+            return captor.getValue().getFeature();
+        }
+    }
+
+    /**
+     * Test that verifies a FeatureCreatedApplicationEvent is published when a feature is created
+     * via the REST API and that the event listener handles the event.
+     */
+    @Test
+    @WithMockOAuth2User(username = "user")
+    void shouldPublishAndHandleEventWhenFeatureCreatedViaAPI() {
+        var payload =
+                """
+            {
+                "productCode": "intellij",
+                "releaseCode": "IDEA-2023.3.8",
+                "title": "Event Test Feature",
+                "description": "Testing event publishing and handling",
+                "assignedTo": "john.doe"
+            }
+            """;
+
+        // Create a feature via the REST API
+        var result = mvc.post()
+                .uri("/api/features")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+                .exchange();
+        assertThat(result).hasStatus(HttpStatus.CREATED);
+        
+        // Verify that the event listener was called
+        testEventListener.verifyEventReceived(1);
+        
+        // Verify feature details from the event
+        Feature feature = testEventListener.getCapturedFeature();
+        assertThat(feature).isNotNull();
+        assertThat(feature.getTitle()).isEqualTo("Event Test Feature");
+    }
+    
+    /**
+     * Test that verifies a FeatureCreatedApplicationEvent is published when a feature is created
+     * directly via the FeatureService and that the event listener handles the event.
+     */
+    @Test
+    void shouldPublishAndHandleEventWhenFeatureCreatedViaService() {
+        // Create a feature via the service
+        CreateFeatureCommand command = new CreateFeatureCommand(
+                "intellij",
+                "IDEA-2023.3.8",
+                "Service Event Test Feature",
+                "Testing event publishing and handling via service",
+                "jane.doe",
+                "test-user"
+        );
+        
+        String featureCode = featureService.createFeature(command);
+        assertThat(featureCode).isNotNull();
+        
+        // Verify that the event listener was called
+        testEventListener.verifyEventReceived(1);
+        
+        // Verify feature details from the event
+        Feature feature = testEventListener.getCapturedFeature();
+        assertThat(feature).isNotNull();
+        assertThat(feature.getTitle()).isEqualTo("Service Event Test Feature");
+    }
+}


### PR DESCRIPTION
Implement a mechanism to publish and listen for feature creation events synchronously within the application. Modify the EventPublisher class to publish a Spring ApplicationEvent in addition to the Kafka event when a new feature is created. Create a new class for the FeatureCreatedApplicationEvent that extends ApplicationEvent. Implement a FeatureEventListener class that listens for the FeatureCreatedApplicationEvent, and log relevant information when the event is handled. Ensure the application can react to feature creation events in real-time for any necessary business logic processing.
