### PR TITLE
Publish Events after Transaction Commit Using @TransactionalEventList…

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/domain/events/FeatureEventListener.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/FeatureEventListener.java
@@ -1,0 +1,43 @@
+package com.sivalabs.ft.features.domain.events;
+
+import com.sivalabs.ft.features.domain.events.internal.InternalFeatureCreatedEvent;
+import com.sivalabs.ft.features.domain.events.internal.InternalFeatureDeletedEvent;
+import com.sivalabs.ft.features.domain.events.internal.InternalFeatureUpdatedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+public class FeatureEventListener {
+    private static final Logger logger = LoggerFactory.getLogger(FeatureEventListener.class);
+    
+    private final EventPublisher eventPublisher;
+
+    public FeatureEventListener(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFeatureCreatedEvent(InternalFeatureCreatedEvent event) {
+        logger.info("Processing feature created event after transaction commit: {}", 
+                event.feature().getCode());
+        eventPublisher.publishFeatureCreatedEvent(event.feature());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFeatureUpdatedEvent(InternalFeatureUpdatedEvent event) {
+        logger.info("Processing feature updated event after transaction commit: {}", 
+                event.feature().getCode());
+        eventPublisher.publishFeatureUpdatedEvent(event.feature());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFeatureDeletedEvent(InternalFeatureDeletedEvent event) {
+        logger.info("Processing feature deleted event after transaction commit: {}", 
+                event.feature().getCode());
+        eventPublisher.publishFeatureDeletedEvent(
+                event.feature(), event.deletedBy(), event.deletedAt());
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/internal/InternalFeatureCreatedEvent.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/internal/InternalFeatureCreatedEvent.java
@@ -1,0 +1,12 @@
+package com.sivalabs.ft.features.domain.events.internal;
+
+import com.sivalabs.ft.features.domain.entities.Feature;
+
+/**
+ * Internal event that is published when a feature is created.
+ * This event is published within the transaction and will be processed
+ * by a TransactionalEventListener after the transaction commits.
+ */
+public record InternalFeatureCreatedEvent(Feature feature) {
+    // Feature entity is passed directly to allow the listener to access all feature data
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/internal/InternalFeatureDeletedEvent.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/internal/InternalFeatureDeletedEvent.java
@@ -1,0 +1,16 @@
+package com.sivalabs.ft.features.domain.events.internal;
+
+import com.sivalabs.ft.features.domain.entities.Feature;
+import java.time.Instant;
+
+/**
+ * Internal event that is published when a feature is deleted.
+ * This event is published within the transaction and will be processed
+ * by a TransactionalEventListener after the transaction commits.
+ */
+public record InternalFeatureDeletedEvent(
+        Feature feature,
+        String deletedBy,
+        Instant deletedAt) {
+    // Additional information about who deleted the feature and when
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/events/internal/InternalFeatureUpdatedEvent.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/events/internal/InternalFeatureUpdatedEvent.java
@@ -1,0 +1,12 @@
+package com.sivalabs.ft.features.domain.events.internal;
+
+import com.sivalabs.ft.features.domain.entities.Feature;
+
+/**
+ * Internal event that is published when a feature is updated.
+ * This event is published within the transaction and will be processed
+ * by a TransactionalEventListener after the transaction commits.
+ */
+public record InternalFeatureUpdatedEvent(Feature feature) {
+    // Feature entity is passed directly to allow the listener to access all feature data
+}

--- a/src/test/java/com/sivalabs/ft/features/domain/events/TransactionPhasesEventListenerTest.java
+++ b/src/test/java/com/sivalabs/ft/features/domain/events/TransactionPhasesEventListenerTest.java
@@ -1,0 +1,105 @@
+package com.sivalabs.ft.features.domain.events;
+
+import com.sivalabs.ft.features.ApplicationProperties;
+import com.sivalabs.ft.features.TestcontainersConfiguration;
+import com.sivalabs.ft.features.domain.Commands;
+import com.sivalabs.ft.features.domain.FeatureService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, TransactionPhasesEventListenerTest.TestConfig.class})
+@Sql(scripts = {"/test-data.sql"})
+class TransactionPhasesEventListenerTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(TransactionPhasesEventListenerTest.class);
+
+    @Autowired
+    private FeatureService featureService;
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Autowired
+    private ApplicationProperties applicationProperties;
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        @Primary
+        public KafkaTemplate<String, Object> kafkaTemplate() {
+            return Mockito.mock(KafkaTemplate.class);
+        }
+    }
+
+    @Test
+    void testEventHandlingTransactionCommit() {
+        Mockito.reset(kafkaTemplate);
+
+        // Given a valid create feature command
+        Commands.CreateFeatureCommand command = new Commands.CreateFeatureCommand(
+                "intellij", // product code from test data
+                "R-2023-Q4", // release code from test data
+                "Test Feature",
+                "Test Description",
+                "assignee",
+                "creator"
+        );
+
+        // When creating a feature (which should succeed)
+        featureService.createFeature(command);
+
+        // Verify that KafkaTemplate was invoked with the correct event and topic
+        ArgumentCaptor<FeatureCreatedEvent> eventCaptor = ArgumentCaptor.forClass(FeatureCreatedEvent.class);
+        ArgumentCaptor<String> topicCaptor = ArgumentCaptor.forClass(String.class);
+
+        Mockito.verify(kafkaTemplate).send(topicCaptor.capture(), eventCaptor.capture());
+
+        // Verify the topic
+        assertThat(topicCaptor.getValue()).isEqualTo(applicationProperties.events().newFeatures());
+
+        // Verify the event
+        FeatureCreatedEvent capturedEvent = eventCaptor.getValue();
+        assertThat(capturedEvent).isNotNull();
+        assertThat(capturedEvent.code()).isNotNull();
+        assertThat(capturedEvent.title()).isEqualTo("Test Feature");
+        assertThat(capturedEvent.description()).isEqualTo("Test Description");
+        assertThat(capturedEvent.assignedTo()).isEqualTo("assignee");
+        assertThat(capturedEvent.createdBy()).isEqualTo("creator");
+    }
+
+    @Test
+    void testEventHandlingTransactionRollback() {
+        Mockito.reset(kafkaTemplate);
+
+        Commands.CreateFeatureCommand command = new Commands.CreateFeatureCommand(
+                "unknown",
+                "unknown", // release code from test data
+                "Test Feature",
+                "Test Description",
+                "assignee",
+                "creator"
+        );
+
+        try {
+            featureService.createFeature(command);
+        } catch (Exception e) {
+        }
+
+        // Verify that KafkaTemplate was not invoked (since the transaction was rolled back)
+        Mockito.verifyNoInteractions(kafkaTemplate);
+    }
+}


### PR DESCRIPTION
…ener #52

Refactor feature creation logic to publish FeatureCreatedEvent via @TransactionalEventListener with the AFTER_COMMIT phase, ensuring the event is only handled after a successful database commit. Add tests to verify that event listeners are invoked only on successful transactions and not on rollbacks. Explore and document other phases such as BEFORE_COMMIT and AFTER_ROLLBACK for advanced scenarios.

FAIL_TO_PASS: com.sivalabs.ft.features.domain.events.TransactionPhasesEventListenerTest